### PR TITLE
Update Sentinel Policy to Support `ssl_mode` for Cloud SQL SSL Enforcement

### DIFF
--- a/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl.sentinel
+++ b/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl.sentinel
@@ -24,7 +24,12 @@ ip_configuration_require_ssl_is_true = rule when deny_undefined_ip_configuration
 	} as _, instances {
 		all instances.change.after.settings as _, setting {
 			all setting.ip_configuration as _, config {
-				config.require_ssl is true
+				(
+				# Check if require_ssl exists and is true
+				(config.require_ssl else null != null and config.require_ssl is true) or
+					# Check if ssl_mode exists and is not `ALLOW_UNENCRYPTED_AND_ENCRYPTED`
+					((config.ssl_mode else null != null) and
+						config.ssl_mode != "ALLOW_UNENCRYPTED_AND_ENCRYPTED"))
 			}
 		}
 	}
@@ -34,7 +39,7 @@ ip_configuration_require_ssl_is_true = rule when deny_undefined_ip_configuration
 // Category:    Database
 // Provider:    hashicorp/google
 // Resource:    google_sql_database_instance
-// Check:       settings.ip_configuration.require_ssl is true
+// Check:       settings.ip_configuration.require_ssl is true or settings.ip_configuration.ssl_mode is not "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 // -------------------------------------------------------------
 // Ensure that Cloud SQL database instance requires all incoming
 // connections to use SSL.

--- a/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/test/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/success-v2.hcl
+++ b/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/test/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/success-v2.hcl
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success-v2.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/testdata/mock-tfplan-success-v2.sentinel
+++ b/policies/cloud-sql-databases-instance-requires-all-incoming-connections-to-use-ssl/testdata/mock-tfplan-success-v2.sentinel
@@ -1,0 +1,185 @@
+resource_changes = {
+	"google_sql_database_instance.mysql56": {
+		"address": "google_sql_database_instance.mysql56",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"database_version": "MYSQL_5_6",
+				"name":             "db",
+				"region":           "us-central1",
+				"settings": [
+					{
+						"authorized_gae_applications": null,
+						"database_flags":              [],
+						"disk_autoresize":             true,
+						"disk_type":                   "PD_HDD",
+						"ip_configuration": [
+							{
+								"authorized_networks": [
+									{
+										"expiration_time": "",
+										"name":            "P1",
+										"value":           "172.16.12.0/24",
+									},
+									{
+										"expiration_time": "",
+										"name":            "P2",
+										"value":           "172.16.0.0/16",
+									},
+								],
+								"private_network": null,
+								"ssl_mode":     "ENCRYPTED_ONLY",
+							},
+						],
+						"maintenance_window": [],
+						"pricing_plan":       "PER_USE",
+						"replication_type":   "SYNCHRONOUS",
+						"tier":               "db-f1-micro",
+						"user_labels":        null,
+					},
+				],
+				"timeouts": null,
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "mysql56",
+		"provider_name":  "google",
+		"type":           "google_sql_database_instance",
+	},
+	"google_sql_database_instance.mysql57": {
+		"address": "google_sql_database_instance.mysql57",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"database_version": "MYSQL_5_7",
+				"name":             "db",
+				"region":           "us-central1",
+				"settings": [
+					{
+						"authorized_gae_applications": null,
+						"database_flags":              [],
+						"disk_autoresize":             true,
+						"disk_type":                   "PD_HDD",
+						"ip_configuration": [
+							{
+								"authorized_networks": [],
+								"private_network":     null,
+								"ssl_mode":         "ENCRYPTED_ONLY",
+							},
+						],
+						"maintenance_window": [],
+						"pricing_plan":       "PER_USE",
+						"replication_type":   "SYNCHRONOUS",
+						"tier":               "db-f1-micro",
+						"user_labels":        null,
+					},
+				],
+				"timeouts": null,
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "mysql57",
+		"provider_name":  "google",
+		"type":           "google_sql_database_instance",
+	},
+	"google_sql_database_instance.pgsql11": {
+		"address": "google_sql_database_instance.pgsql11",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"database_version": "POSTGRES_11",
+				"name":             "db",
+				"region":           "us-central1",
+				"settings": [
+					{
+						"authorized_gae_applications": null,
+						"database_flags":              [],
+						"disk_autoresize":             true,
+						"disk_type":                   "PD_HDD",
+						"ip_configuration": [
+							{
+								"authorized_networks": [],
+								"private_network":     null,
+								"ssl_mode":         "ENCRYPTED_ONLY",
+							},
+						],
+						"maintenance_window": [],
+						"pricing_plan":       "PER_USE",
+						"replication_type":   "SYNCHRONOUS",
+						"tier":               "db-f1-micro",
+						"user_labels":        null,
+					},
+				],
+				"timeouts": null,
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "pgsql11",
+		"provider_name":  "google",
+		"type":           "google_sql_database_instance",
+	},
+	"google_sql_database_instance.pgsql96": {
+		"address": "google_sql_database_instance.pgsql96",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"database_version": "POSTGRES_9_6",
+				"name":             "db",
+				"region":           "us-central1",
+				"settings": [
+					{
+						"authorized_gae_applications": null,
+						"database_flags":              [],
+						"disk_autoresize":             true,
+						"disk_type":                   "PD_HDD",
+						"ip_configuration": [
+							{
+								"authorized_networks": [],
+								"private_network":     null,
+								"ssl_mode":         "ENCRYPTED_ONLY",
+							},
+						],
+						"maintenance_window": [],
+						"pricing_plan":       "PER_USE",
+						"replication_type":   "SYNCHRONOUS",
+						"tier":               "db-f1-micro",
+						"user_labels":        null,
+					},
+				],
+				"timeouts": null,
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "pgsql96",
+		"provider_name":  "google",
+		"type":           "google_sql_database_instance",
+	},
+}


### PR DESCRIPTION
**Overview:**
This PR fixes issue [#7](https://github.com/hashicorp/policy-library-gcp-databases-terraform/issues/7) by adding a conditional check for `ssl_mode` while keeping support for the deprecated `require_ssl`. This ensures compatibility with both older and newer versions of the Google provider. 

**Details:**
- Added logic to check `ssl_mode` in addition to `require_ssl`. `ssl_mode` can be one of the following. The condition checks to ensure `ssl_mode` is not set as `ALLOW_UNENCRYPTED_AND_ENCRYPTED`

SSL MODE | DESCRIPTION 
-- | --
ALLOW_UNENCRYPTED_AND_ENCRYPTED | Allow non-SSL/non-TLS and SSL/TLS connections. For SSL connections to MySQL and PostgreSQL, the client certificate isn't verified.When this value is used, the legacy requireSsl flag must be false or cleared to avoid a conflict between the values of the two flags.
ENCRYPTED_ONLY | Only allow connections encrypted with SSL/TLS. For SSL connections to MySQL and PostgreSQL, the client certificate isn't verified.When this value is used, the legacy requireSsl flag must be false or cleared to avoid a conflict between the values of the two flags.
TRUSTED_CLIENT_CERTIFICATE_REQUIRED | Only allow connections encrypted with SSL/TLS and with valid client certificates.


[source](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/instances#SslMode)

**Testing:**
- Added mock test to validate the policy where require_ssl doesn’t exist but policy should still pass since SSL is enforced via ssl_mode